### PR TITLE
test: validate prev-run CI optimization (push 1)

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/DriverInfo.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/DriverInfo.java
@@ -67,5 +67,6 @@ final class DriverInfo
         }
     }
 
+    // test-ci-smart-prev-run-skip: push 1 marker (module A: client/trino-jdbc)
     private DriverInfo() {}
 }

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcPlugin.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcPlugin.java
@@ -18,6 +18,7 @@ import io.trino.plugin.jdbc.JdbcPlugin;
 public class DruidJdbcPlugin
         extends JdbcPlugin
 {
+    // test-ci-smart-prev-run-skip: push 2 marker (module B: plugin/trino-druid)
     public DruidJdbcPlugin()
     {
         super("druid", DruidJdbcClientModule::new);


### PR DESCRIPTION
Validation PR for the prev-run CI optimization on branch
`findepi/feature/ci-smart-prev-run-skip-testing`.

## Test plan

- [x] **Push 1** (this commit): touches `client/trino-jdbc`. Expected:
  - `resolve-prev-run` finds no prior run; outputs empty.
  - `build-test-matrix` produces a matrix narrowed to modules impacted vs master.
  - `test (client/trino-jdbc, core/trino-spi, core/trino-web-ui)` runs.
- [ ] **Push 2** (follow-up): will touch a *different* module (e.g. `plugin/trino-druid`). Expected:
  - `resolve-prev-run` finds run 1 as prev; emits its merge SHA and (likely empty) deny list.
  - `build-test-matrix` second GIB pass identifies only the newly-touched module as impacted-vs-prev.
  - The `client/trino-jdbc` group is SKIPPED in run 2 (passed prev, no new diff).
  - The new module's matrix item runs.

This is a fork-scoped test. **DO NOT MERGE.**